### PR TITLE
Bugfix: Add statefulsetspec.template.spec.tolerations to the JSONSchema

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -218,6 +218,28 @@ func getCustomResourceDefinationSchema() *apiextensionsv1.JSONSchemaProps {
 													},
 												},
 											},
+											"tolerations": {
+												Type: "array",
+												Items: &apiextensionsv1.JSONSchemaPropsOrArray{
+													Schema: &apiextensionsv1.JSONSchemaProps{
+														Type: "object",
+														Properties: map[string]apiextensionsv1.JSONSchemaProps{
+															"key": {
+																Type: "string",
+															},
+															"operator": {
+																Type: "string",
+															},
+															"value": {
+																Type: "string",
+															},
+															"effect": {
+																Type: "string",
+															},
+														},
+													},
+												},
+											},
 										},
 									},
 								},


### PR DESCRIPTION
### Summary

Adds statefulsetspec.template.spec.tolerations to the JSONSchema for the collector. This will allow collector pods to schedule on nodes with taints

### Background

This is already intended to be a feature, but it does not work properly. It appears that the tolerations just don't un-marshal. This fixes the issue. I have tested this in one of our environments, but please let me know if you need any additional proof or testing.

I originally opened an [issue](https://github.com/logicmonitor/k8s-helm-charts/issues/101) on the helm chart, but the tolerations and nodeSelector are definitely generated by the helm chart correctly. Some change was made that finally started applying the nodeSelector, but the tolerations are still not going through to the collector. This fix will remedy that.